### PR TITLE
Use WeakMap instead of a plain object for storage

### DIFF
--- a/doc/can-dom-data.clean.md
+++ b/doc/can-dom-data.clean.md
@@ -1,0 +1,30 @@
+@function can-dom-data.clean domData.clean
+@parent can-dom-data
+
+Remove data from an element previously added by [can-dom-data.set set].
+
+@signature `domData.clean.call(element, key)`
+@param  {String} key The property to remove from the element’s data.
+
+@body
+
+## Use
+
+```js
+import domData from "can-dom-data";
+
+const element = document.createElement("p");
+document.body.appendChild(element);
+
+domData.set.call(element, "metadata", {
+  hello: "world"
+});
+
+let metadata = domData.get.call(element, "metadata");
+// metadata is {hello: "world"}
+
+domData.clean.call(element, "metadata");
+
+metadata = domData.get.call(element, "metadata");
+// metadata === undefined after clean() was called
+```

--- a/doc/can-dom-data.delete.md
+++ b/doc/can-dom-data.delete.md
@@ -1,0 +1,29 @@
+@function can-dom-data.delete domData.delete
+@parent can-dom-data
+
+Remove all data for an element previously added by [can-dom-data.set set].
+
+@signature `domData.delete.call(element)`
+
+@body
+
+## Use
+
+```js
+import domData from "can-dom-data";
+
+const element = document.createElement("p");
+document.body.appendChild(element);
+
+domData.set.call(element, "metadata", {
+  hello: "world"
+});
+
+let metadata = domData.get.call(element, "metadata");
+// metadata is {hello: "world"}
+
+domData.delete.call(element, "metadata");
+
+metadata = domData.get.call(element, "metadata");
+// metadata === undefined after clean() was called
+```

--- a/doc/can-dom-data.get.md
+++ b/doc/can-dom-data.get.md
@@ -1,0 +1,26 @@
+@function can-dom-data.get domData.get
+@parent can-dom-data
+
+Get data that was stored in a DOM Node using the specified `key`.
+
+@signature `domData.get.call(element, key)`
+@param  {String} key The property to retrieve from the element’s data.
+@return {*} value The value stored for the key.
+
+@body
+
+## Use
+
+```js
+import domData from "can-dom-data";
+
+const element = document.createElement("p");
+document.body.appendChild(element);
+
+domData.set.call(element, "metadata", {
+  hello: "world"
+});
+
+let metadata = domData.get.call(element, "metadata");
+// metadata is {hello: "world"}
+```

--- a/doc/can-dom-data.md
+++ b/doc/can-dom-data.md
@@ -1,0 +1,31 @@
+@module {{}} can-dom-data
+@parent can-dom-utilities
+@collection can-infrastructure
+@description Associate key/value pair data with a DOM node in a memory-safe way.
+
+@type {Object} The `can-dom-data` package exports an object with
+[can-dom-data.clean clean], [can-dom-data.delete delete], [can-dom-data.get get],
+and [can-dom-data.set set] methods.
+
+@body
+
+## Use
+
+```js
+import domData from "can-dom-data";
+
+const element = document.createElement("p");
+document.body.appendChild(element);
+
+domData.set.call(element, "metadata", {
+  hello: "world"
+});
+
+let metadata = domData.get.call(element, "metadata");
+// metadata is {hello: "world"}
+
+document.body.removeChild(element);
+
+metadata = domData.get.call(element, "metadata");
+// metadata === undefined because the element was removed from the DOM
+```

--- a/doc/can-dom-data.set.md
+++ b/doc/can-dom-data.set.md
@@ -1,0 +1,24 @@
+@function can-dom-data.set domData.set
+@parent can-dom-data
+
+Set data to be associated with a DOM node using the specified `key`.
+If data already exists for this key, it will be overwritten.
+
+@signature `domData.set.call(element, key, value)`
+@param  {String} key The property under which to store the value.
+@param {*} value The value to store for the key.
+
+@body
+
+## Use
+
+```js
+import domData from "can-dom-data";
+
+const element = document.createElement("p");
+document.body.appendChild(element);
+
+domData.set.call(element, "metadata", {
+  hello: "world"
+});
+```

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     ]
   },
   "dependencies": {
-    "can-cid": "^1.1.0",
     "can-dom-mutate": "^1.0.0",
     "can-namespace": "1.0.0"
   },

--- a/test/memory-test.js
+++ b/test/memory-test.js
@@ -1,4 +1,3 @@
-var cid = require('can-cid');
 var unit = require('steal-qunit');
 var domData = require('../can-dom-data');
 var domMutate = require('can-dom-mutate');
@@ -24,21 +23,4 @@ unit.test('should clean up data when a node is removed from the document', funct
 	});
 
 	slot.removeChild(node);
-});
-
-unit.test('should not setup cleanup for non-Node objects', function (assert) {
-	var notNode = {};
-	domData.set.call(notNode, 'foo', 'bar');
-	assert.deepEqual(domData._removalDisposalMap, {}, 'should have no disposals');
-
-	domData.delete.call(notNode);
-});
-
-unit.test('should dispose of the subscription when all data is removed from a node', function (assert) {
-	var node = document.createElement('div');
-	domData.set.call(node, 'foo', 'bar');
-	domData.clean.call(node, 'foo');
-	assert.deepEqual(domData._removalDisposalMap, {}, 'should have no disposals');
-
-	domData.delete.call(node);
 });


### PR DESCRIPTION
can-dom-data now uses a WeakMap with elements as keys and plain objects as values to store the key/value pairs that are set.

WeakMap guarantees that when there are no other references to its keys (elements in this case), then the values will be garbage collected, which means can-dom-data does not need to track when the DOM is mutated and remove the data it stores about elements.

Screenshots of the docs:

<details>
<summary>Navigation</summary>
<img width="231" alt="screen shot 2018-03-27 at 1 21 49 pm" src="https://user-images.githubusercontent.com/10070176/37993223-b9790b48-31c2-11e8-9692-8d81982a1f19.png">
</details>

<details>
<summary>can-dom-data</summary>
<img width="728" alt="screen shot 2018-03-27 at 1 25 19 pm" src="https://user-images.githubusercontent.com/10070176/37993222-b95f32c2-31c2-11e8-97f1-30cd627ceca4.png">
</details>

<details>
<summary>domData.clean</summary>
<img width="724" alt="screen shot 2018-03-27 at 1 25 37 pm" src="https://user-images.githubusercontent.com/10070176/37993221-b947c4b6-31c2-11e8-9964-31163ef9dd59.png">
</details>

<details>
<summary>domData.delete</summary>
<img width="720" alt="screen shot 2018-03-27 at 1 25 52 pm" src="https://user-images.githubusercontent.com/10070176/37993220-b930222a-31c2-11e8-8694-7889d6655e79.png">
</details>

<details>
<summary>domData.get</summary>
<img width="723" alt="screen shot 2018-03-27 at 1 26 09 pm" src="https://user-images.githubusercontent.com/10070176/37993219-b914dc22-31c2-11e8-82e5-9e00421ca819.png">
</details>

<details>
<summary>domData.set</summary>
<img width="746" alt="screen shot 2018-03-27 at 1 26 49 pm" src="https://user-images.githubusercontent.com/10070176/37993218-b8fb159e-31c2-11e8-94fa-d16f5069b113.png">
</details>